### PR TITLE
Avoids unnecessary array construction

### DIFF
--- a/lib/barrage/cpu.rb
+++ b/lib/barrage/cpu.rb
@@ -10,21 +10,21 @@ class CPU
     plot.pointsize "0.5"
 
     parsed = Dstat.parse(file, 1)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "usr"
       ds.with = "filledcurve linetype 7"
       ds.linewidth = 2
     end
 
     parsed = Dstat.parse(file, 2)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "sys"
       ds.with = "filledcurve linetype 3"
       ds.linewidth = 2
     end
 
     parsed = Dstat.parse(file, 4)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "iowait"
       ds.with = "filledcurve linetype 5"
       ds.linewidth = 2

--- a/lib/barrage/memory.rb
+++ b/lib/barrage/memory.rb
@@ -8,7 +8,7 @@ class Memory
     plot.ylabel "memory (megabytes)"
 
     parsed = Dstat.parse(file, 7)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "used"
       ds.with = "filledcurve linetype 7"
       ds.linewidth = 2
@@ -16,7 +16,7 @@ class Memory
     end
 
     parsed = Dstat.parse(file, 8)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "buffered"
       ds.with = "filledcurve linetype 3"
       ds.linewidth = 2
@@ -24,7 +24,7 @@ class Memory
     end
 
     parsed = Dstat.parse(file, 9)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "cached"
       ds.with = "filledcurve linetype 5"
       ds.linewidth = 2

--- a/lib/barrage/network.rb
+++ b/lib/barrage/network.rb
@@ -8,7 +8,7 @@ class Network
     plot.ylabel "throughput (mbps)"
 
     parsed = Dstat.parse(file, 16)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "received"
       ds.with = "filledcurve linetype 7"
       ds.linewidth = 2
@@ -16,7 +16,7 @@ class Network
     end
 
     parsed = Dstat.parse(file, 17)
-    plot.data << Gnuplot::DataSet.new( [parsed[0], parsed[1]] ) do |ds|
+    plot.data << Gnuplot::DataSet.new(parsed) do |ds|
       ds.title = "sent"
       ds.with = "filledcurve linetype 3"
       ds.linewidth = 2


### PR DESCRIPTION
DstatParser#parse already returns an array of the expected format, so
it is unnecessary to further construct an array like so.
If deconstruction is wanted in the future, more semantic names could be
given by doing `first_elem, second_elem = DstatParser.parse(file, 1)`.
