### PR TITLE
Relies on truthiness of the value

### DIFF
--- a/lib/barrage/dstat.rb
+++ b/lib/barrage/dstat.rb
@@ -17,12 +17,12 @@ class Dstat
     count = 0
     CSV.foreach(file) do |row|
 
-      if start_parsing == true then
+      if start_parsing
         time.push(count - 7)
         values.push(row[column])
       end
 
-      if start_parsing == false && count == 7
+      if !start_parsing && count == 7
         start_parsing = true
       end
 


### PR DESCRIPTION
Idiomatically Rubyists don't compare directly to boolean values,
relying on truthiness rules. I _think_ only false and nil are false,
being all else true.
